### PR TITLE
Adding compatibility with redmine 3.4.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ This allows a user to quickly jump to github, gitlab, bitbucket, a code review w
 $ cd redmine/plugins
 $ git clone https://github.com/tleish/redmine_remote_revision_url
 ```
-
+So run the following command for db migration
+```
+$ rake redmine:plugins NAME=redmine_remote_revision_url RAILS_ENV=production
+```
 Restart Redmine
 
 ## Repository Settings

--- a/app/views/redmine_remote_revision_url/_settings.html.erb
+++ b/app/views/redmine_remote_revision_url/_settings.html.erb
@@ -1,11 +1,13 @@
-<% @settings = {} unless @settings.is_a? Hash %>
-
 <div>
-  <%= check_box_tag 'settings[replace_revision_link]', true, @settings['replace_revision_link'] %>
+  <%= hidden_field_tag 'settings[replace_revision_link]', 0 %>
+  <%= check_box_tag 'settings[replace_revision_link]', 1, @settings[:replace_revision_link].to_i == 1 %>
   Replace the Redmine Revision Links (instead of adding additional link)
 </div>
 
+<br />
+
 <div>
-  <%= check_box_tag 'settings[open_in_new_window]', true, @settings['open_in_new_window'] %>
+  <%= hidden_field_tag 'settings[open_in_new_window]', 0 %>
+  <%= check_box_tag 'settings[open_in_new_window]', 1, @settings[:open_in_new_window].to_i == 1 %>
   Open Remote Revision Links in New Tab/Window
 </div>

--- a/db/migrate/001_update_saved_settings.rb
+++ b/db/migrate/001_update_saved_settings.rb
@@ -1,0 +1,18 @@
+class UpdateSavedSettings < ActiveRecord::Migration
+  def up
+    setting = Setting.find_by(name: 'plugin_redmine_remote_revision_url')
+
+    if setting && setting.value.is_a?(Hash)
+      setting.value = ActionController::Parameters.new({
+        replace_revision_link: setting.value.try(:[], :replace_revision_link) == 'true' ? '1' : '0',
+        open_in_new_window: setting.value.try(:[], :open_in_new_window) == 'true' ? '1' : '0'
+      })
+      setting.save!
+    else
+      Setting.where(name: 'plugin_redmine_remote_revision_url').destroy_all
+    end
+  end
+
+  def down
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -10,8 +10,13 @@ Redmine::Plugin.register :redmine_remote_revision_url do
   name 'Remote Revision URL'
   author 'Thomas Leishman'
   description 'The Redmine Remote Revision URL plugin adds a revision link to a remote website to see more details on a commit/revision.'
-  version '0.3.1'
+  version '0.3.2'
   url 'https://github.com/tleish/redmine_remote_revision_url'
   author_url 'https://github.com/tleish'
-  settings :default => { display_under_single_revision: true, display_under_associated_revisions: false } , :partial => 'redmine_remote_revision_url/settings'
+  settings :default => {
+    display_under_single_revision: true,
+    display_under_associated_revisions: false,
+    replace_revision_link: 0,
+    open_in_new_window: 0
+  }, :partial => 'redmine_remote_revision_url/settings'
 end

--- a/lib/redmine_remote_revision_url/application_helper_patch.rb
+++ b/lib/redmine_remote_revision_url/application_helper_patch.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
 
   def link_to_revision_method(repository)
     return :original_link_to_revision if repository.extra_remote_revision_url.blank?
-    return :replace_link_to_web_revision if plugin_redmine_remote_revision_url('replace_revision_link')
+    return :replace_link_to_web_revision if Setting.plugin_redmine_remote_revision_url[:replace_revision_link].to_i == 1
     :combine_link_to_web_revision
   end
 
@@ -46,12 +46,8 @@ module ApplicationHelper
   end
 
   def link_to_web_revision_target
-    open_in_new_window = plugin_redmine_remote_revision_url('open_in_new_window')
+    open_in_new_window = Setting.plugin_redmine_remote_revision_url[:open_in_new_window].to_i == 1
     open_in_new_window ? '_blank' : '_top'
   end
 
-  def plugin_redmine_remote_revision_url(setting)
-    return nil unless Setting.plugin_redmine_remote_revision_url.is_a? Hash
-    Setting.plugin_redmine_remote_revision_url[setting]
-  end
 end

--- a/lib/redmine_remote_revision_url/repositories_helper_patch.rb
+++ b/lib/redmine_remote_revision_url/repositories_helper_patch.rb
@@ -5,7 +5,7 @@ RepositoriesHelper.class_eval do
   def repository_field_tags(form, repository)
     html = original_repository_field_tags(form, repository)
     html += extra_remote_revision_url_tag(form)
-    html += extra_remote_revision_text_tag(form) unless plugin_redmine_remote_revision_url('replace_revision_link')
+    html += extra_remote_revision_text_tag(form) if Setting.plugin_redmine_remote_revision_url[:replace_revision_link].to_i == 1
     html
   end
 


### PR DESCRIPTION
1. Adding compatibility with redmine 3.4.2.
2. Migration to update the saved settings if they are correct and to delete them if not was added.